### PR TITLE
fix bug, process correctly filenames with whitespaces

### DIFF
--- a/zenodo_upload.sh
+++ b/zenodo_upload.sh
@@ -8,10 +8,10 @@ set -e
 
 # strip deposition url prefix if provided; see https://github.com/jhpoelen/zenodo-upload/issues/2#issuecomment-797657717
 DEPOSITION=$( echo $1 | sed 's+^http[s]*://zenodo.org/deposit/++g' )
-FILEPATH=$2
+FILEPATH="$2"
 FILENAME=$(echo $FILEPATH | sed 's+.*/++g')
 
 BUCKET=$(curl -H @<(echo -e "Accept: application/json\nAuthorization: Bearer $ZENODO_TOKEN") "https://www.zenodo.org/api/deposit/depositions/$DEPOSITION" | jq --raw-output .links.bucket)
 
 
-curl --progress-bar -o /dev/null -H @<(echo -e "Authorization: Bearer $ZENODO_TOKEN") --upload-file $FILEPATH $BUCKET/$FILENAME
+curl --progress-bar -o /dev/null -H @<(echo -e "Authorization: Bearer $ZENODO_TOKEN") --upload-file "$FILEPATH" $BUCKET/"$FILENAME"


### PR DESCRIPTION
If the file to be uploaded has a white space in the path or file name (e.g. "my file.zip"), the script gives an error because it splits the filename "my file.zip" into "my" and "file.zip", instead of treating it as a single input argument