### PR TITLE
Sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ export ZENODO_TOKEN=[Zenodo access token]
 5. in the browser, copy the deposition id (e.g., in ```https://zenodo.org/deposit/12345``` , 12345 is the deposition id)
 6. in terminal and upload a file using
 ```bash
-./zenodo_upload.sh [deposition id] [filename]
+./zenodo_upload.sh [-s] <deposition id> <filename>
 ```
+Including option `-s` will upload the file to ```https://sandbox.zenodo.org/deposit/12346```instead. 
 7. on completion, you should see something like:
 ```shell
 + curl ...

--- a/zenodo_upload.sh
+++ b/zenodo_upload.sh
@@ -23,10 +23,10 @@ shift "$(( OPTIND - 1 ))"
 
 
 # strip deposition url prefix if provided; see https://github.com/jhpoelen/zenodo-upload/issues/2#issuecomment-797657717
-DEPOSITION=$( echo $1 | sed 's+^http[s]*://zenodo.org/deposit/++g' )
+DEPOSITION=$( echo $1 | sed "s+^http[s]*://${SBSTR}zenodo.org/deposit/++g" )
 FILEPATH="$2"
 FILENAME=$(echo $FILEPATH | sed 's+.*/++g')
 
-BUCKET=$(curl https://zenodo.org/api/deposit/depositions/"$DEPOSITION"?access_token="$ZENODO_TOKEN" | jq --raw-output .links.bucket)
+BUCKET=$(curl https://${SBSTR}zenodo.org/api/deposit/depositions/"$DEPOSITION"?access_token="$ZENODO_TOKEN" | jq --raw-output .links.bucket)
 
 curl --progress-bar -o /dev/null --upload-file "$FILEPATH" $BUCKET/"$FILENAME"?access_token="$ZENODO_TOKEN"

--- a/zenodo_upload.sh
+++ b/zenodo_upload.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Upload big files to Zenodo.
 #
-# usage: ./zenodo_upload.sh [deposition id] [filename]
-#
+# usage: ./zenodo_upload.sh [-sb] <deposition id> <filename> 
+# -sb ... upload to zenodo sandbox
 
 set -e
 

--- a/zenodo_upload.sh
+++ b/zenodo_upload.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Upload big files to Zenodo.
 #
-# usage: ./zenodo_upload.sh [-sb] <deposition id> <filename> 
-# -sb ... upload to zenodo sandbox
+# usage: ./zenodo_upload.sh [-s] <deposition id> <filename> 
+# -s ... upload to zenodo sandbox
 
 set -e
 

--- a/zenodo_upload.sh
+++ b/zenodo_upload.sh
@@ -6,6 +6,22 @@
 
 set -e
 
+SBSTR=""
+
+while getopts "s" opt; do
+    case $opt in
+	    "s") echo "running in sandbox mode" >&2 
+		SBSTR="sandbox."
+		;;
+	     *) echo "Error: invalid option" >&2
+		exit 1
+		;;
+    esac
+done
+# reset option index for positional arguments later
+shift "$(( OPTIND - 1 ))"
+
+
 # strip deposition url prefix if provided; see https://github.com/jhpoelen/zenodo-upload/issues/2#issuecomment-797657717
 DEPOSITION=$( echo $1 | sed 's+^http[s]*://zenodo.org/deposit/++g' )
 FILEPATH="$2"


### PR DESCRIPTION
Added option handling to allow for uploads to sandbox.zenodo.org ( Issue #9 )
The upload command can be run as before or including ```-s``` which adds "sandbox." to the URLs.

Invalid options will throw an error and exit.